### PR TITLE
Make static INIT not mut and don't call it unsafely

### DIFF
--- a/oqs/src/lib.rs
+++ b/oqs/src/lib.rs
@@ -52,13 +52,10 @@ mod macros;
 ///
 /// This method is thread-safe and can be called more than once.
 pub fn init() {
-    static mut INIT: Once = Once::new();
-    // Unsafe is necessary for mutually accessing static var INIT
-    unsafe {
-        INIT.call_once(|| {
-            ffi::common::OQS_init();
-        });
-    }
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        unsafe { ffi::common::OQS_init() };
+    });
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
`Once::call_once` takes `&self` and not `&mut self`. This is part of what makes it a synchronization primitive. As a result, the static does not need to be mutable and the call does not need to be unsafe. Only the FFI function call itself is unsafe here.