### PR TITLE
Remove redundant #[must_use]

### DIFF
--- a/oqs/src/lib.rs
+++ b/oqs/src/lib.rs
@@ -72,7 +72,6 @@ pub enum Error {
 impl std::error::Error for Error {}
 
 /// Result type for operations that may fail
-#[must_use]
 pub type Result<T> = std::result::Result<T, Error>;
 
 impl std::fmt::Display for Error {


### PR DESCRIPTION
Very small nitpicky PR. Sorry about that. But `#[must_use]` is not needed here as it's just a type alias. That property will carry over automatically from `std::result::Result`.